### PR TITLE
Refactor build to use CMake library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.16)
+project(UniDesign LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
+file(GLOB LIB_SOURCES CONFIGURE_DEPENDS "${SRC_DIR}/*.cpp")
+list(REMOVE_ITEM LIB_SOURCES "${SRC_DIR}/Main.cpp")
+
+add_library(unidesign STATIC ${LIB_SOURCES})
+set_target_properties(unidesign PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories(unidesign
+    PUBLIC
+        ${SRC_DIR}
+)
+
+if (MSVC)
+    target_compile_options(unidesign PRIVATE /W0 /O2)
+else()
+    target_compile_options(unidesign PRIVATE -w -O3 -ffast-math)
+endif()
+
+add_executable(UniDesign "${SRC_DIR}/Main.cpp")
+
+target_link_libraries(UniDesign PRIVATE unidesign)
+
+if (MSVC)
+    target_compile_options(UniDesign PRIVATE /W0 /O2)
+else()
+    target_compile_options(UniDesign PRIVATE -w -O3 -ffast-math)
+endif()

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,7 @@
-#!/usr/bin/bash
-g++ -w -O3 --fast-math -o UniDesign src/*.cpp
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR="build"
+
+cmake -S . -B "${BUILD_DIR}" -DCMAKE_BUILD_TYPE=Release
+cmake --build "${BUILD_DIR}" --config Release


### PR DESCRIPTION
## Summary
- add a top-level CMakeLists that builds all core sources into a static `unidesign` library and a CLI executable linked against it
- configure shared compiler flags and include paths so both targets reuse the same objects
- update the build script to invoke CMake configure and build steps for the new layout

## Testing
- ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d66c406bf483289546cba37802a9b4