### PR TITLE
Add RAII SequenceHandle wrapper and test coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,76 @@
+cmake_minimum_required(VERSION 3.16)
+project(UniDesign LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_library(unidesign STATIC
+  src/Atom.cpp
+  src/AtomParamsSet.cpp
+  src/Chain.cpp
+  src/DesignSite.cpp
+  src/EnergyFunction.cpp
+  src/EnergyMatrix.cpp
+  src/ErrorTracker.cpp
+  src/EvoAminoName.cpp
+  src/EvoGetPhiPsi.cpp
+  src/EvoGetSeq2SA.cpp
+  src/EvoGetSeq2SS.cpp
+  src/EvoSeqAlign.cpp
+  src/EvoUtility.cpp
+  src/Evolution.cpp
+  src/GeometryCalc.cpp
+  src/Getopt.cpp
+  src/ProgramFunction.cpp
+  src/ProgramPreprocess.cpp
+  src/ProteinDesign.cpp
+  src/Residue.cpp
+  src/ResidueTopology.cpp
+  src/Rotamer.cpp
+  src/RotamerBuilder.cpp
+  src/RotamerOptimizer.cpp
+  src/Sequence.cpp
+  src/SmallMol.cpp
+  src/SmallMolEEF1.cpp
+  src/SmallMolParAndTopo.cpp
+  src/Structure.cpp
+  src/Utility.cpp
+  src/WeightOpt.cpp
+)
+
+target_sources(unidesign
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/unidesign/SequenceHandle.hpp>
+)
+
+target_include_directories(unidesign
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+)
+
+target_compile_definitions(unidesign
+  PUBLIC
+    $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
+)
+
+add_executable(unidesign_cli src/Main.cpp)
+target_link_libraries(unidesign_cli PRIVATE unidesign)
+
+if (PROJECT_IS_TOP_LEVEL)
+  enable_testing()
+
+  add_executable(sequence_handle_tests tests/SequenceHandleTests.cpp)
+  target_link_libraries(sequence_handle_tests PRIVATE unidesign)
+  add_test(NAME SequenceHandleTests COMMAND sequence_handle_tests)
+
+  find_package(pybind11 QUIET)
+  if (pybind11_FOUND)
+    pybind11_add_module(unidesign_python MODULE bindings/python/SequenceBindings.cpp)
+    target_link_libraries(unidesign_python PRIVATE unidesign)
+    target_include_directories(unidesign_python PRIVATE include src)
+    target_compile_definitions(unidesign_python PRIVATE UNIDESIGN_ENABLE_PYBIND11)
+  endif()
+endif()
+

--- a/bindings/python/SequenceBindings.cpp
+++ b/bindings/python/SequenceBindings.cpp
@@ -1,0 +1,25 @@
+#include "unidesign/SequenceHandle.hpp"
+
+#ifdef UNIDESIGN_ENABLE_PYBIND11
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace {
+
+unidesign::SequenceHandle clone_sequence(const unidesign::SequenceHandle& source) {
+  return unidesign::SequenceHandle(source);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_unidesign, m) {
+  py::class_<unidesign::SequenceHandle>(m, "SequenceHandle")
+      .def(py::init<>())
+      .def("clone", &clone_sequence)
+      .def("raw", [](unidesign::SequenceHandle& handle) { return handle.get(); },
+           py::return_value_policy::reference);
+}
+
+#endif  // UNIDESIGN_ENABLE_PYBIND11
+

--- a/include/unidesign/SequenceHandle.hpp
+++ b/include/unidesign/SequenceHandle.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include "Sequence.h"
+
+namespace unidesign {
+
+class SequenceError : public std::runtime_error {
+public:
+  SequenceError(const std::string& context, int code)
+      : std::runtime_error(context + " failed with error code " + std::to_string(code)), code_(code) {}
+
+  int code() const noexcept { return code_; }
+
+private:
+  int code_;
+};
+
+class SequenceHandle {
+public:
+  SequenceHandle()
+      : seq_(allocateSequence()) {}
+
+  SequenceHandle(const SequenceHandle& other)
+      : seq_(nullptr) {
+    copyFrom(other);
+  }
+
+  SequenceHandle& operator=(const SequenceHandle& other) {
+    if (this != &other) {
+      copyFrom(other);
+    }
+    return *this;
+  }
+
+  SequenceHandle(SequenceHandle&& other) noexcept = default;
+  SequenceHandle& operator=(SequenceHandle&& other) noexcept = default;
+
+  ~SequenceHandle() { reset(); }
+
+  Sequence* get() noexcept { return seq_.get(); }
+  const Sequence* get() const noexcept { return seq_.get(); }
+
+  Sequence& operator*() {
+    if (!seq_) {
+      throw std::runtime_error("SequenceHandle does not own a Sequence");
+    }
+    return *seq_;
+  }
+
+  const Sequence& operator*() const {
+    if (!seq_) {
+      throw std::runtime_error("SequenceHandle does not own a Sequence");
+    }
+    return *seq_;
+  }
+
+  Sequence* operator->() noexcept { return seq_.get(); }
+  const Sequence* operator->() const noexcept { return seq_.get(); }
+
+private:
+  struct SequenceStorageDeleter {
+    void operator()(Sequence* seq) const noexcept { delete seq; }
+  };
+
+  using Storage = std::unique_ptr<Sequence, SequenceStorageDeleter>;
+
+  static Storage allocateSequence() {
+    Storage seq(new Sequence{});
+    const int result = SequenceCreate(seq.get());
+    if (result != Success) {
+      SequenceDestroy(seq.get());
+      throw SequenceError("SequenceCreate", result);
+    }
+    return seq;
+  }
+
+  void ensureAllocated() {
+    if (!seq_) {
+      seq_ = allocateSequence();
+    }
+  }
+
+  void reset() noexcept {
+    if (seq_) {
+      SequenceDestroy(seq_.get());
+      seq_.reset();
+    }
+  }
+
+  void copyFrom(const SequenceHandle& other) {
+    if (!other.seq_) {
+      reset();
+      ensureAllocated();
+      return;
+    }
+
+    ensureAllocated();
+    const int result = SequenceCopy(seq_.get(), const_cast<Sequence*>(other.seq_.get()));
+    if (result != Success) {
+      SequenceDestroy(seq_.get());
+      const int recreate = SequenceCreate(seq_.get());
+      if (recreate != Success) {
+        throw SequenceError("SequenceCreate", recreate);
+      }
+      throw SequenceError("SequenceCopy", result);
+    }
+  }
+
+  Storage seq_;
+};
+
+}  // namespace unidesign
+

--- a/tests/SequenceHandleTests.cpp
+++ b/tests/SequenceHandleTests.cpp
@@ -1,0 +1,40 @@
+#include "unidesign/SequenceHandle.hpp"
+
+#include <cassert>
+#include <utility>
+
+double CUT_EXCL_LOW_PROB_ROT = 0.03;
+double CUT_TORSION_DEVIATION = 20.0;
+BOOL FLAG_READ_HYDROGEN = TRUE;
+BOOL FLAG_WRITE_HYDROGEN = TRUE;
+char MOL2[MAX_LEN_FILE_NAME + 1] = "";
+char DES_CHAINS[MAX_LEN_ONE_LINE_CONTENT + 1] = "";
+
+int main() {
+  unidesign::SequenceHandle handle;
+  handle->desSiteCount = 3;
+  handle->etot = 4.2;
+
+  unidesign::SequenceHandle copy(handle);
+  assert(copy->desSiteCount == 3);
+  assert(copy->etot == 4.2);
+
+  unidesign::SequenceHandle assigned;
+  assigned = handle;
+  assert(assigned->desSiteCount == 3);
+  assert(assigned->etot == 4.2);
+
+  unidesign::SequenceHandle moved(std::move(handle));
+  assert(moved->desSiteCount == 3);
+  assert(moved->etot == 4.2);
+  assert(handle.get() == nullptr);
+
+  unidesign::SequenceHandle moveAssigned;
+  moveAssigned = std::move(copy);
+  assert(moveAssigned->desSiteCount == 3);
+  assert(moveAssigned->etot == 4.2);
+  assert(copy.get() == nullptr);
+
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- add a SequenceHandle RAII wrapper that manages Sequence lifetime, copy semantics, and pointer-style accessors
- register the new header with the unidesign target, add a basic SequenceHandle test, and create optional pybind11 bindings that use the wrapper
- introduce a CMake-based build that wires the library, CLI, test target, and optional Python module

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68d66ecb0f8883288f0ae26facd1a9c1