### PR TITLE
Add RAII-managed handles for Structure and Sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,36 @@ All protein design tasks are conducted with UniDesign command <i><b>ProteinDesig
 ## Installation, Usage and Tutorial
 Please refer to the <a href=https://github.com/tommyhuangthu/UniDesign/blob/master/manual.docx>manual.docx</a> for details.
 
+## Managed C++ helpers for Structure and Sequence
+Repeated manual calls to `StructureCreate`/`StructureDestroy` and `SequenceCreate`/`SequenceDestroy` (for example, the loops in `src/ProteinDesign.cpp` that rebuild temporary sequences) can now be replaced with RAII helpers declared in `src/ManagedTypes.hpp`. The `StructureHandle` and `SequenceHandle` classes automatically invoke the appropriate `Create` routine on construction, perform `Copy` on copy/move, and guarantee `Destroy` is executed exactly once, preventing double frees.
+
+```cpp
+#include "ManagedTypes.hpp"
+
+void OptimizeDesign()
+{
+  StructureHandle structure;           // StructureCreate + StructureDestroy are automatic
+  SequenceHandle workingSequence;
+
+  StructureHandle reference = structure; // uses StructureCopy under the hood
+  workingSequence = SequenceHandle{};    // resets via copy-and-swap semantics
+
+  // Access the underlying C structs when calling existing APIs.
+  PerformDesign(structure.get(), workingSequence.get());
+}
+```
+
+For code exposed through pybind11, the handles can be bound directly while still returning raw pointers to existing C APIs:
+
+```cpp
+py::class_<StructureHandle>(m, "StructureHandle")
+  .def(py::init<>())
+  .def("raw", [](StructureHandle& self) { return self.get(); },
+       py::return_value_policy::reference);
+```
+
+Developers that prefer pointer semantics can also use `StructurePtr`/`SequencePtr`, which are `std::unique_ptr` aliases with custom deleters that call the corresponding `Destroy` routine before deleting the raw pointer.
+
 ## Contact
 For suggestions, please contact xiaoqiah@umich.edu or xiaoqiah@outlook.com.
 

--- a/src/ManagedTypes.hpp
+++ b/src/ManagedTypes.hpp
@@ -1,0 +1,185 @@
+#ifndef MANAGED_TYPES_HPP
+#define MANAGED_TYPES_HPP
+
+#include "Structure.h"
+#include "Sequence.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace managed_types_detail
+{
+inline void ThrowIfFailed(int code, const char* functionName)
+{
+  if (FAILED(code))
+  {
+    throw std::runtime_error(std::string(functionName) + " failed with error code " + std::to_string(code));
+  }
+}
+} // namespace managed_types_detail
+
+class StructureHandle
+{
+public:
+  StructureHandle()
+  {
+    managed_types_detail::ThrowIfFailed(StructureCreate(&mValue), "StructureCreate");
+  }
+
+  ~StructureHandle()
+  {
+    StructureDestroy(&mValue);
+  }
+
+  StructureHandle(const StructureHandle& other)
+  {
+    managed_types_detail::ThrowIfFailed(StructureCreate(&mValue), "StructureCreate");
+    managed_types_detail::ThrowIfFailed(StructureCopy(&mValue, const_cast<Structure*>(&other.mValue)), "StructureCopy");
+  }
+
+  StructureHandle(StructureHandle&& other) noexcept
+  {
+    managed_types_detail::ThrowIfFailed(StructureCreate(&mValue), "StructureCreate");
+    swap(other);
+  }
+
+  StructureHandle& operator=(StructureHandle other) noexcept
+  {
+    swap(other);
+    return *this;
+  }
+
+  void swap(StructureHandle& other) noexcept
+  {
+    using std::swap;
+    swap(mValue, other.mValue);
+  }
+
+  Structure* get() noexcept { return &mValue; }
+  const Structure* get() const noexcept { return &mValue; }
+
+  Structure& operator*() noexcept { return mValue; }
+  const Structure& operator*() const noexcept { return mValue; }
+
+  Structure* operator->() noexcept { return &mValue; }
+  const Structure* operator->() const noexcept { return &mValue; }
+
+private:
+  Structure mValue{};
+};
+
+inline void swap(StructureHandle& lhs, StructureHandle& rhs) noexcept
+{
+  lhs.swap(rhs);
+}
+
+class SequenceHandle
+{
+public:
+  SequenceHandle()
+  {
+    managed_types_detail::ThrowIfFailed(SequenceCreate(&mValue), "SequenceCreate");
+  }
+
+  ~SequenceHandle()
+  {
+    SequenceDestroy(&mValue);
+  }
+
+  SequenceHandle(const SequenceHandle& other)
+  {
+    managed_types_detail::ThrowIfFailed(SequenceCreate(&mValue), "SequenceCreate");
+    managed_types_detail::ThrowIfFailed(SequenceCopy(&mValue, const_cast<Sequence*>(&other.mValue)), "SequenceCopy");
+  }
+
+  SequenceHandle(SequenceHandle&& other) noexcept
+  {
+    managed_types_detail::ThrowIfFailed(SequenceCreate(&mValue), "SequenceCreate");
+    swap(other);
+  }
+
+  SequenceHandle& operator=(SequenceHandle other) noexcept
+  {
+    swap(other);
+    return *this;
+  }
+
+  void swap(SequenceHandle& other) noexcept
+  {
+    using std::swap;
+    swap(mValue, other.mValue);
+  }
+
+  Sequence* get() noexcept { return &mValue; }
+  const Sequence* get() const noexcept { return &mValue; }
+
+  Sequence& operator*() noexcept { return mValue; }
+  const Sequence& operator*() const noexcept { return mValue; }
+
+  Sequence* operator->() noexcept { return &mValue; }
+  const Sequence* operator->() const noexcept { return &mValue; }
+
+private:
+  Sequence mValue{};
+};
+
+inline void swap(SequenceHandle& lhs, SequenceHandle& rhs) noexcept
+{
+  lhs.swap(rhs);
+}
+
+struct StructureDeleter
+{
+  void operator()(Structure* ptr) const noexcept
+  {
+    if (ptr != nullptr)
+    {
+      StructureDestroy(ptr);
+      delete ptr;
+    }
+  }
+};
+
+using StructurePtr = std::unique_ptr<Structure, StructureDeleter>;
+
+inline StructureHandle MakeStructure()
+{
+  return StructureHandle{};
+}
+
+inline StructurePtr MakeStructurePtr()
+{
+  StructurePtr ptr(new Structure{});
+  managed_types_detail::ThrowIfFailed(StructureCreate(ptr.get()), "StructureCreate");
+  return ptr;
+}
+
+struct SequenceDeleter
+{
+  void operator()(Sequence* ptr) const noexcept
+  {
+    if (ptr != nullptr)
+    {
+      SequenceDestroy(ptr);
+      delete ptr;
+    }
+  }
+};
+
+using SequencePtr = std::unique_ptr<Sequence, SequenceDeleter>;
+
+inline SequenceHandle MakeSequence()
+{
+  return SequenceHandle{};
+}
+
+inline SequencePtr MakeSequencePtr()
+{
+  SequencePtr ptr(new Sequence{});
+  managed_types_detail::ThrowIfFailed(SequenceCreate(ptr.get()), "SequenceCreate");
+  return ptr;
+}
+
+#endif // MANAGED_TYPES_HPP


### PR DESCRIPTION
## Summary
- add `StructureHandle` and `SequenceHandle` RAII wrappers plus smart-pointer helpers in `ManagedTypes.hpp`
- document how to adopt the new managed types, including a pybind11 usage example, in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d67698c6388328baf08290ccafa091