### PR TITLE
Add Python helpers for locating UniDesign assets

### DIFF
--- a/python/unidesign/__init__.py
+++ b/python/unidesign/__init__.py
@@ -1,0 +1,12 @@
+"""Python helpers for interacting with the UniDesign toolchain."""
+
+from __future__ import annotations
+
+from .exceptions import BinaryDiscoveryError, UniDesignError
+from .paths import discover_binary
+
+__all__ = [
+    "discover_binary",
+    "BinaryDiscoveryError",
+    "UniDesignError",
+]

--- a/python/unidesign/exceptions.py
+++ b/python/unidesign/exceptions.py
@@ -1,0 +1,22 @@
+"""Custom exception types for the UniDesign Python helpers."""
+
+from __future__ import annotations
+
+
+class UniDesignError(RuntimeError):
+    """Base class for exceptions raised by the UniDesign helpers."""
+
+
+class BinaryDiscoveryError(UniDesignError):
+    """Raised when the compiled UniDesign binary cannot be located or used."""
+
+    def __init__(self, message: str, *, attempted_paths: tuple[str, ...] | None = None) -> None:
+        super().__init__(message)
+        self.attempted_paths = attempted_paths or ()
+
+    def __str__(self) -> str:  # pragma: no cover - trivial wrapper for repr
+        base = super().__str__()
+        if self.attempted_paths:
+            attempts = ", ".join(str(path) for path in self.attempted_paths)
+            return f"{base} (checked: {attempts})"
+        return base

--- a/python/unidesign/paths.py
+++ b/python/unidesign/paths.py
@@ -1,0 +1,98 @@
+"""Utilities for discovering UniDesign assets relative to this package."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, Tuple
+
+from .exceptions import BinaryDiscoveryError
+
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent
+_PROJECT_ROOT = _PACKAGE_ROOT.parent.parent
+
+
+def project_root() -> Path:
+    """Return the repository root that mirrors ``PROGRAM_PATH`` in ``Main.cpp``."""
+
+    return _PROJECT_ROOT
+
+
+def _resource_dir(name: str) -> Path:
+    candidate = _PROJECT_ROOT / name
+    if not candidate.is_dir():
+        raise FileNotFoundError(
+            f"Expected UniDesign resource directory '{name}' at {candidate!s}."
+        )
+    return candidate
+
+
+def library_dir() -> Path:
+    """Return the path to the UniDesign ``library`` directory."""
+
+    return _resource_dir("library")
+
+
+def wread_dir() -> Path:
+    """Return the path to the UniDesign ``wread`` directory."""
+
+    return _resource_dir("wread")
+
+
+def extbin_dir() -> Path:
+    """Return the path to the UniDesign ``extbin`` directory."""
+
+    return _resource_dir("extbin")
+
+
+def _candidate_binary_paths() -> Tuple[Path, ...]:
+    search_roots: Iterable[Path] = (
+        _PROJECT_ROOT,
+        _PROJECT_ROOT / "build",
+        _PROJECT_ROOT / "bin",
+    )
+    binary_names = ("UniDesign", "UniDesign.exe")
+    candidates: list[Path] = []
+    for root in search_roots:
+        for name in binary_names:
+            candidate = root / name
+            if candidate not in candidates:
+                candidates.append(candidate)
+    return tuple(candidates)
+
+
+def discover_binary() -> Path:
+    """Locate the compiled UniDesign executable.
+
+    The search mirrors the C++ entry point by resolving paths relative to this
+    module. The helper validates executability and raises
+    :class:`BinaryDiscoveryError` if discovery fails.
+    """
+
+    attempted: list[str] = []
+    not_executable: list[str] = []
+    for candidate in _candidate_binary_paths():
+        attempted.append(str(candidate))
+        if candidate.is_file():
+            if os.access(candidate, os.X_OK):
+                return candidate
+            not_executable.append(str(candidate))
+    if not_executable:
+        raise BinaryDiscoveryError(
+            "UniDesign binary exists but is not executable.",
+            attempted_paths=tuple(not_executable),
+        )
+    raise BinaryDiscoveryError(
+        "UniDesign binary could not be located. Build the project before proceeding.",
+        attempted_paths=tuple(attempted),
+    )
+
+
+__all__ = [
+    "project_root",
+    "library_dir",
+    "wread_dir",
+    "extbin_dir",
+    "discover_binary",
+]


### PR DESCRIPTION
## Summary
- add a `python/unidesign` helper package with public `discover_binary` API
- provide custom exceptions and resource-directory helpers mirroring Main.cpp initialization
- expose the discovery helper at package level for easy reuse

## Testing
- `PYTHONPATH=python python - <<'PY'
from unidesign import discover_binary
print(discover_binary())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d68e95d18c8328a83736a8d3aea467