### PR TITLE
Add UniDesign job wrappers and artifact helpers

### DIFF
--- a/python/unidesign/__init__.py
+++ b/python/unidesign/__init__.py
@@ -10,6 +10,16 @@ from .config import (
     ProteinDesignConfig,
 )
 from .exceptions import BinaryDiscoveryError, UniDesignError
+from .jobs import (
+    BindingComputationJob,
+    BindingComputationResult,
+    LigandParameterizationJob,
+    LigandParameterizationResult,
+    ProteinDesignJob,
+    ProteinDesignResult,
+    StabilityComputationJob,
+    StabilityComputationResult,
+)
 from .paths import discover_binary
 from .runner import UniDesignRunResult, UniDesignRunner
 
@@ -24,4 +34,12 @@ __all__ = [
     "ComputeStabilityConfig",
     "ComputeBindingConfig",
     "MakeLigParamConfig",
+    "ProteinDesignJob",
+    "ProteinDesignResult",
+    "StabilityComputationJob",
+    "StabilityComputationResult",
+    "BindingComputationJob",
+    "BindingComputationResult",
+    "LigandParameterizationJob",
+    "LigandParameterizationResult",
 ]

--- a/python/unidesign/jobs/__init__.py
+++ b/python/unidesign/jobs/__init__.py
@@ -1,0 +1,21 @@
+"""High-level job interfaces for UniDesign commands."""
+
+from .design import ProteinDesignJob, ProteinDesignResult
+from .energy import (
+    BindingComputationJob,
+    BindingComputationResult,
+    StabilityComputationJob,
+    StabilityComputationResult,
+)
+from .ligand import LigandParameterizationJob, LigandParameterizationResult
+
+__all__ = [
+    "ProteinDesignJob",
+    "ProteinDesignResult",
+    "StabilityComputationJob",
+    "StabilityComputationResult",
+    "BindingComputationJob",
+    "BindingComputationResult",
+    "LigandParameterizationJob",
+    "LigandParameterizationResult",
+]

--- a/python/unidesign/jobs/_shared.py
+++ b/python/unidesign/jobs/_shared.py
@@ -1,0 +1,97 @@
+"""Shared helpers for job wrappers."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping
+
+
+@dataclass(slots=True)
+class JobArtifact:
+    """Representation of a generated UniDesign file."""
+
+    path: Path
+
+    def read_text(self, encoding: str = "utf-8") -> str:
+        """Read the artifact as text using the provided encoding."""
+
+        return self.path.read_text(encoding=encoding)
+
+    def read_bytes(self) -> bytes:
+        """Read the artifact in binary mode."""
+
+        return self.path.read_bytes()
+
+    def open(self, mode: str = "r", *args, **kwargs):
+        """Open the underlying file handle."""
+
+        return self.path.open(mode, *args, **kwargs)
+
+
+def _existing_artifacts(workdir: Path, candidates: Mapping[str, Path]) -> dict[str, Path]:
+    existing: dict[str, Path] = {}
+    for name, relative_path in candidates.items():
+        candidate = workdir / relative_path
+        if candidate.exists():
+            existing[name] = candidate
+    return existing
+
+
+def relocate_artifacts(
+    workdir: Path,
+    candidates: Mapping[str, Path],
+    *,
+    keep_workspace: bool,
+) -> tuple[Path, dict[str, JobArtifact], Callable[[], None]]:
+    """Relocate generated files based on caller preferences.
+
+    Parameters
+    ----------
+    workdir:
+        Temporary directory that holds the UniDesign execution artefacts.
+    candidates:
+        Mapping of artifact names to paths relative to ``workdir``.
+    keep_workspace:
+        Whether the caller wants to retain the original ``workdir``.
+
+    Returns
+    -------
+    workspace:
+        Directory retained for downstream consumers. When ``keep_workspace`` is
+        ``False`` a new directory is created and populated with only the
+        generated artefacts.
+    artifacts:
+        Mapping of artifact names to :class:`JobArtifact` instances.
+    cleanup:
+        Callable that removes ``workspace`` when invoked.
+    """
+
+    existing = _existing_artifacts(workdir, candidates)
+
+    if keep_workspace:
+        artifacts = {name: JobArtifact(path=path) for name, path in existing.items()}
+        cleanup = lambda: shutil.rmtree(workdir, ignore_errors=True)
+        return workdir, artifacts, cleanup
+
+    destination = Path(tempfile.mkdtemp(prefix="unidesign_artifacts_"))
+    relocated: dict[str, JobArtifact] = {}
+
+    for name, source in existing.items():
+        try:
+            relative = source.relative_to(workdir)
+        except ValueError:
+            relative = Path(source.name)
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+        relocated[name] = JobArtifact(path=target)
+
+    shutil.rmtree(workdir, ignore_errors=True)
+    cleanup = lambda: shutil.rmtree(destination, ignore_errors=True)
+    return destination, relocated, cleanup
+
+
+__all__ = ["JobArtifact", "relocate_artifacts"]

--- a/python/unidesign/jobs/design.py
+++ b/python/unidesign/jobs/design.py
@@ -1,0 +1,94 @@
+"""Design-focused job wrappers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping
+
+from ..config import ProteinDesignConfig
+from ..runner import UniDesignRunner, UniDesignRunResult
+from ._shared import JobArtifact, relocate_artifacts
+
+
+@dataclass(slots=True)
+class ProteinDesignResult:
+    """Result bundle returned by :class:`ProteinDesignJob`."""
+
+    run: UniDesignRunResult
+    workspace: Path
+    self_energy: JobArtifact | None
+    rotamer_list: JobArtifact | None
+    rotamer_list_secondary: JobArtifact | None
+    design_rotamer_indices: JobArtifact | None
+    design_sequences: JobArtifact | None
+    best_sequences: JobArtifact | None
+    best_structure: JobArtifact | None
+    best_sites: JobArtifact | None
+    best_mutation_sites: JobArtifact | None
+    best_ligand_pose: JobArtifact | None
+    cleanup: Callable[[], None] | None
+
+    def close(self) -> None:
+        """Remove the workspace retained for this result."""
+
+        if self.cleanup is not None:
+            self.cleanup()
+            self.cleanup = None
+
+
+class ProteinDesignJob:
+    """Execute ``ProteinDesign`` with structured inputs and outputs."""
+
+    def __init__(self, runner: UniDesignRunner, config: ProteinDesignConfig) -> None:
+        self._runner = runner
+        self._config = config
+
+    def _candidate_files(self, prefix: str) -> Mapping[str, Path]:
+        return {
+            "self_energy": Path(f"{prefix}_selfenergy.txt"),
+            "rotamer_list": Path(f"{prefix}_rotlist.txt"),
+            "rotamer_list_secondary": Path(f"{prefix}_rotlistSEC.txt"),
+            "design_rotamer_indices": Path(f"{prefix}_desrots"),
+            "design_sequences": Path(f"{prefix}_desseqs"),
+            "best_sequences": Path(f"{prefix}_bestseqs"),
+            "best_structure": Path(f"{prefix}_beststruct"),
+            "best_sites": Path(f"{prefix}_bestsites"),
+            "best_mutation_sites": Path(f"{prefix}_bestmutsites"),
+            "best_ligand_pose": Path(f"{prefix}_bestlig"),
+        }
+
+    def run(
+        self,
+        *,
+        keep_workspace: bool = False,
+        env: Mapping[str, str] | None = None,
+    ) -> ProteinDesignResult:
+        """Execute the UniDesign ``ProteinDesign`` command."""
+
+        run_result = self._runner.run(
+            self._config.to_cli_args(), env=env, persist_workdir=True
+        )
+        workspace, artifacts, cleanup = relocate_artifacts(
+            run_result.workdir, self._candidate_files(run_result.prefix), keep_workspace=keep_workspace
+        )
+        run_result.workdir = workspace
+
+        return ProteinDesignResult(
+            run=run_result,
+            workspace=workspace,
+            self_energy=artifacts.get("self_energy"),
+            rotamer_list=artifacts.get("rotamer_list"),
+            rotamer_list_secondary=artifacts.get("rotamer_list_secondary"),
+            design_rotamer_indices=artifacts.get("design_rotamer_indices"),
+            design_sequences=artifacts.get("design_sequences"),
+            best_sequences=artifacts.get("best_sequences"),
+            best_structure=artifacts.get("best_structure"),
+            best_sites=artifacts.get("best_sites"),
+            best_mutation_sites=artifacts.get("best_mutation_sites"),
+            best_ligand_pose=artifacts.get("best_ligand_pose"),
+            cleanup=cleanup,
+        )
+
+
+__all__ = ["ProteinDesignJob", "ProteinDesignResult"]

--- a/python/unidesign/jobs/energy.py
+++ b/python/unidesign/jobs/energy.py
@@ -1,0 +1,107 @@
+"""Energy computation job wrappers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping
+
+from ..config import ComputeBindingConfig, ComputeStabilityConfig
+from ..runner import UniDesignRunner, UniDesignRunResult
+from ._shared import JobArtifact, relocate_artifacts
+
+
+@dataclass(slots=True)
+class StabilityComputationResult:
+    """Encapsulates outputs for ``ComputeStability`` runs."""
+
+    run: UniDesignRunResult
+    workspace: Path
+    rotamer_list: JobArtifact | None
+    cleanup: Callable[[], None] | None
+
+    def close(self) -> None:
+        if self.cleanup is not None:
+            self.cleanup()
+            self.cleanup = None
+
+
+class StabilityComputationJob:
+    """Execute the ``ComputeStability`` command."""
+
+    def __init__(self, runner: UniDesignRunner, config: ComputeStabilityConfig) -> None:
+        self._runner = runner
+        self._config = config
+
+    def run(
+        self,
+        *,
+        keep_workspace: bool = False,
+        env: Mapping[str, str] | None = None,
+    ) -> StabilityComputationResult:
+        run_result = self._runner.run(
+            self._config.to_cli_args(), env=env, persist_workdir=True
+        )
+        candidates = {
+            "rotamer_list": Path(f"{run_result.prefix}_rotlist.txt"),
+        }
+        workspace, artifacts, cleanup = relocate_artifacts(
+            run_result.workdir, candidates, keep_workspace=keep_workspace
+        )
+        run_result.workdir = workspace
+
+        return StabilityComputationResult(
+            run=run_result,
+            workspace=workspace,
+            rotamer_list=artifacts.get("rotamer_list"),
+            cleanup=cleanup,
+        )
+
+
+@dataclass(slots=True)
+class BindingComputationResult:
+    """Encapsulates outputs for ``ComputeBinding`` runs."""
+
+    run: UniDesignRunResult
+    workspace: Path
+    cleanup: Callable[[], None] | None
+
+    def close(self) -> None:
+        if self.cleanup is not None:
+            self.cleanup()
+            self.cleanup = None
+
+
+class BindingComputationJob:
+    """Execute the ``ComputeBinding`` command."""
+
+    def __init__(self, runner: UniDesignRunner, config: ComputeBindingConfig) -> None:
+        self._runner = runner
+        self._config = config
+
+    def run(
+        self,
+        *,
+        keep_workspace: bool = False,
+        env: Mapping[str, str] | None = None,
+    ) -> BindingComputationResult:
+        run_result = self._runner.run(
+            self._config.to_cli_args(), env=env, persist_workdir=True
+        )
+        workspace, _, cleanup = relocate_artifacts(
+            run_result.workdir, {}, keep_workspace=keep_workspace
+        )
+        run_result.workdir = workspace
+        return BindingComputationResult(
+            run=run_result,
+            workspace=workspace,
+            cleanup=cleanup,
+        )
+
+
+__all__ = [
+    "StabilityComputationJob",
+    "StabilityComputationResult",
+    "BindingComputationJob",
+    "BindingComputationResult",
+]

--- a/python/unidesign/jobs/ligand.py
+++ b/python/unidesign/jobs/ligand.py
@@ -1,0 +1,63 @@
+"""Ligand preparation job wrappers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping
+
+from ..config import MakeLigParamConfig
+from ..runner import UniDesignRunner, UniDesignRunResult
+from ._shared import JobArtifact, relocate_artifacts
+
+
+@dataclass(slots=True)
+class LigandParameterizationResult:
+    """Outputs for ``MakeLigParamAndTopo`` executions."""
+
+    run: UniDesignRunResult
+    workspace: Path
+    parameter_file: JobArtifact | None
+    topology_file: JobArtifact | None
+    cleanup: Callable[[], None] | None
+
+    def close(self) -> None:
+        if self.cleanup is not None:
+            self.cleanup()
+            self.cleanup = None
+
+
+class LigandParameterizationJob:
+    """Execute the ``MakeLigParamAndTopo`` command."""
+
+    def __init__(self, runner: UniDesignRunner, config: MakeLigParamConfig) -> None:
+        self._runner = runner
+        self._config = config
+
+    def run(
+        self,
+        *,
+        keep_workspace: bool = False,
+        env: Mapping[str, str] | None = None,
+    ) -> LigandParameterizationResult:
+        run_result = self._runner.run(
+            self._config.to_cli_args(), env=env, persist_workdir=True
+        )
+        candidates = {
+            "parameter_file": Path(self._config.ligand_parameter_path),
+            "topology_file": Path(self._config.ligand_topology_path),
+        }
+        workspace, artifacts, cleanup = relocate_artifacts(
+            run_result.workdir, candidates, keep_workspace=keep_workspace
+        )
+        run_result.workdir = workspace
+        return LigandParameterizationResult(
+            run=run_result,
+            workspace=workspace,
+            parameter_file=artifacts.get("parameter_file"),
+            topology_file=artifacts.get("topology_file"),
+            cleanup=cleanup,
+        )
+
+
+__all__ = ["LigandParameterizationJob", "LigandParameterizationResult"]


### PR DESCRIPTION
## Summary
- add job modules that execute ProteinDesign, ComputeStability, ComputeBinding, and MakeLigParamAndTopo via UniDesignRunner
- introduce reusable artifact relocation logic so job results expose generated files with optional workspace retention
- export the new job APIs from the package entry point for easy consumption

## Testing
- `python -m compileall python/unidesign/jobs python/unidesign/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68d68c4661a48328bdd6ed7e18cf90cf