### PR TITLE
Add documentation, examples, and tests for Python wrapper

### DIFF
--- a/.github/workflows/python-wrapper.yml
+++ b/.github/workflows/python-wrapper.yml
@@ -1,0 +1,40 @@
+name: Python wrapper
+
+on:
+  push:
+    paths:
+      - 'python/**'
+      - 'examples/python/**'
+      - 'docs/python-wrapper/**'
+      - '.github/workflows/python-wrapper.yml'
+  pull_request:
+    paths:
+      - 'python/**'
+      - 'examples/python/**'
+      - 'docs/python-wrapper/**'
+      - '.github/workflows/python-wrapper.yml'
+
+jobs:
+  tests-and-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest sphinx
+
+      - name: Run python wrapper tests
+        run: |
+          pytest python/tests
+
+      - name: Build wrapper documentation
+        run: |
+          sphinx-build -b html docs/python-wrapper docs/_build/python-wrapper

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+docs/_build/
+__pycache__/
+.python-version
+.pytest_cache/

--- a/docs/python-wrapper/conf.py
+++ b/docs/python-wrapper/conf.py
@@ -1,0 +1,29 @@
+"""Sphinx configuration for the UniDesign Python wrapper documentation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import sys
+
+# Ensure the bundled Python package can be discovered when using autodoc
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PYTHON_DIR = PROJECT_ROOT / "python"
+if PYTHON_DIR.exists():
+    sys.path.insert(0, str(PYTHON_DIR))
+
+project = "UniDesign Python Wrapper"
+copyright = f"{datetime.utcnow():%Y}, UniDesign developers"
+author = "UniDesign developers"
+
+extensions: list[str] = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+]
+
+templates_path: list[str] = []
+exclude_patterns: list[str] = []
+
+html_theme = "alabaster"
+html_static_path: list[str] = []

--- a/docs/python-wrapper/index.rst
+++ b/docs/python-wrapper/index.rst
@@ -1,0 +1,194 @@
+UniDesign Python Wrapper Guide
+==============================
+
+.. contents:: Table of contents
+   :local:
+   :depth: 2
+
+Overview
+--------
+
+The :mod:`unidesign` Python package wraps the UniDesign command line binary with
+high-level helpers that simplify the preparation of command arguments, the
+management of temporary working directories, and the collection of generated
+artefacts. This guide explains how to set up the wrapper, documents the
+available commands, clarifies how temporary files are handled, and highlights
+options for persisting results.
+
+Setup
+-----
+
+Binary discovery
+~~~~~~~~~~~~~~~~
+
+#. Build the UniDesign executable using the provided :mod:`build.sh` helper or
+   by invoking your preferred C++ toolchain manually. The wrapper will look for
+   ``UniDesign`` or ``UniDesign.exe`` in the repository root, ``build/`` and
+   ``bin/`` directories.
+#. When the executable is not present or lacks the executable bit, the helper
+   :func:`unidesign.discover_binary` raises
+   :class:`unidesign.BinaryDiscoveryError` describing the attempted search
+   locations. The error can be surfaced to users of CLI tools to instruct them
+   to build the project first.
+
+Python environment
+~~~~~~~~~~~~~~~~~~
+
+The wrapper ships as a plain Python package under ``python/unidesign`` with no
+external dependencies. Add the ``python`` directory to :envvar:`PYTHONPATH` or
+install the package into a virtual environment using ``pip install -e
+python``. Tests and examples in this repository run with Python 3.9+, although
+newer interpreters are supported.
+
+Initialising a runner
+~~~~~~~~~~~~~~~~~~~~~
+
+The :class:`unidesign.UniDesignRunner` class is responsible for invoking the
+binary while ensuring required resource directories (``library/``, ``wread/``
+and ``extbin/``) are available in the working directory. Typical initialisation
+looks like:
+
+.. code-block:: python
+
+   from unidesign import UniDesignRunner, discover_binary
+
+   binary_path = discover_binary()
+   runner = UniDesignRunner(
+       binary_path,
+       default_env={"OMP_NUM_THREADS": "8"},
+   )
+
+The optional ``default_env`` mapping is merged with the current process
+environment for every invocation. Per-call overrides can be supplied via the
+``env=`` keyword argument of :meth:`UniDesignRunner.run`.
+
+Command usage
+-------------
+
+Monomer and interface design
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :class:`unidesign.ProteinDesignConfig` to describe protein-design settings
+and :class:`unidesign.jobs.ProteinDesignJob` to execute the command. For
+example, the script at :file:`examples/python/monomer_design.py` runs a
+single-trajectory monomer design against the bundled
+:file:`example/MonomerDesign/1igd/1igd.pdb` structure:
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from unidesign import ProteinDesignConfig, UniDesignRunner, discover_binary
+   from unidesign.jobs import ProteinDesignJob
+   from unidesign.paths import project_root
+
+   pdb_path = project_root() / "example/MonomerDesign/1igd/1igd.pdb"
+   config = ProteinDesignConfig(pdb_path=pdb_path, design_chains="A", n_trajectories=1)
+
+   runner = UniDesignRunner(discover_binary())
+   job = ProteinDesignJob(runner, config)
+   result = job.run()
+   try:
+       if result.best_structure:
+           print("Best structure saved to", result.best_structure.path)
+   finally:
+       result.close()
+
+The job wrapper returns a :class:`unidesign.jobs.ProteinDesignResult` bundling
+the captured stdout/stderr, relocated artefacts (self-energy report, sequence
+sets, structures, ligand poses), and a ``close`` method that removes the
+workspace on demand.
+
+Energy scoring
+~~~~~~~~~~~~~~
+
+The wrapper offers dedicated helpers for the ``ComputeStability`` and
+``ComputeBinding`` commands. The script at
+:file:`examples/python/energy_scoring.py` demonstrates both jobs:
+
+.. code-block:: python
+
+   from unidesign import ComputeBindingConfig, ComputeStabilityConfig, UniDesignRunner, discover_binary
+   from unidesign.jobs import BindingComputationJob, StabilityComputationJob
+   from unidesign.paths import project_root
+
+   runner = UniDesignRunner(discover_binary())
+   pdb_path = project_root() / "example/ProteinProteinInteractionDesign/1ay7/1ay7.pdb"
+
+   stability = StabilityComputationJob(runner, ComputeStabilityConfig(pdb_path=pdb_path))
+   stability_result = stability.run()
+   try:
+       if stability_result.rotamer_list:
+           print("Rotamer list saved to", stability_result.rotamer_list.path)
+   finally:
+       stability_result.close()
+
+   binding = BindingComputationJob(runner, ComputeBindingConfig(pdb_path=pdb_path))
+   binding_result = binding.run()
+   binding_result.close()
+
+Ligand parameter generation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Ligand parameterisation is handled by
+:class:`unidesign.MakeLigParamConfig` and
+:class:`unidesign.jobs.LigandParameterizationJob`. The script at
+:file:`examples/python/ligand_parameters.py` turns the bundled
+:file:`example/ProteinLigandInteraction/1r091_BS01_JEN/lig_charge.mol2` file
+into parameter and topology artefacts, persisting them to the chosen output
+location.
+
+Temporary workspace behaviour
+------------------------------
+
+Each :meth:`UniDesignRunner.run` invocation creates a dedicated temporary
+workspace. By default these directories are deleted as soon as the subprocess
+completes, mirroring the behaviour of :class:`tempfile.TemporaryDirectory`.
+Callers can set ``persist_workdir=True`` to retain the original directory for
+inspection or additional post-processing. The generated result object includes
+these fields:
+
+``args``
+    Argument vector used to run the binary (excluding the executable path).
+``stdout`` / ``stderr``
+    Captured process output streams.
+``workdir``
+    Path to the directory containing inputs and outputs for the execution.
+``prefix``
+    Unique prefix injected automatically into CLI arguments to namespace
+    generated files.
+
+Persistence options
+-------------------
+
+Job helpers always invoke the runner with ``persist_workdir=True`` and then
+relocate artefacts into a caller-visible directory:
+
+* When ``keep_workspace=False`` (default) a new directory under
+  ``unidesign_artifacts_<uuid>`` is created, populated only with discovered
+  artefacts, and returned via ``result.workspace``.
+* Setting ``keep_workspace=True`` preserves the original workspace produced by
+  the runner. This is useful when debugging or when additional intermediate
+  files are required.
+
+All result containers expose a ``close()`` method that removes the workspace and
+invalidates further file access. Individual artefacts also provide a
+:meth:`unidesign.artifacts.UniDesignArtifact.persist` helper to copy the file
+into a user-controlled location for long-term storage.
+
+Testing and CI
+--------------
+
+Pytest-based smoke tests under :file:`python/tests/` simulate each command and
+verify that artefacts are captured correctly. The GitHub Actions workflow
+:file:`.github/workflows/python-wrapper.yml` runs these tests and builds this
+Sphinx documentation to guard against regressions in the Python wrapper.
+
+Additional resources
+--------------------
+
+* :file:`examples/python/` contains runnable scripts demonstrating the wrapper
+  APIs.
+* :mod:`unidesign.config` documents the full set of command-line options
+  exposed by the wrapper. Autodoc stubs can be added to this documentation set
+  to include API reference material as the wrapper evolves.

--- a/examples/python/energy_scoring.py
+++ b/examples/python/energy_scoring.py
@@ -1,0 +1,51 @@
+"""Example script demonstrating energy-scoring helpers."""
+
+from __future__ import annotations
+
+from unidesign import (
+    BinaryDiscoveryError,
+    ComputeBindingConfig,
+    ComputeStabilityConfig,
+    UniDesignRunner,
+    discover_binary,
+)
+from unidesign.jobs import BindingComputationJob, StabilityComputationJob
+from unidesign.paths import project_root
+
+
+def main() -> None:
+    try:
+        binary = discover_binary()
+    except BinaryDiscoveryError as exc:  # pragma: no cover - runtime safeguard
+        raise SystemExit(f"UniDesign binary could not be located: {exc}") from exc
+
+    runner = UniDesignRunner(binary)
+    pdb_path = project_root() / "example/ProteinProteinInteractionDesign/1ay7/1ay7.pdb"
+    if not pdb_path.is_file():
+        raise SystemExit(f"Example PDB file not found: {pdb_path}")
+
+    stability_job = StabilityComputationJob(
+        runner,
+        ComputeStabilityConfig(pdb_path=pdb_path),
+    )
+    stability_result = stability_job.run()
+    try:
+        print("Stability return code:", stability_result.run.returncode)
+        if stability_result.rotamer_list:
+            print("Rotamer list:", stability_result.rotamer_list.path)
+    finally:
+        stability_result.close()
+
+    binding_job = BindingComputationJob(
+        runner,
+        ComputeBindingConfig(pdb_path=pdb_path),
+    )
+    binding_result = binding_job.run()
+    try:
+        print("Binding return code:", binding_result.run.returncode)
+    finally:
+        binding_result.close()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution hook
+    main()

--- a/examples/python/ligand_parameters.py
+++ b/examples/python/ligand_parameters.py
@@ -1,0 +1,45 @@
+"""Generate ligand parameters using the UniDesign Python wrapper."""
+
+from __future__ import annotations
+
+from unidesign import (
+    BinaryDiscoveryError,
+    MakeLigParamConfig,
+    UniDesignRunner,
+    discover_binary,
+)
+from unidesign.jobs import LigandParameterizationJob
+from unidesign.paths import project_root
+
+
+def main() -> None:
+    try:
+        binary = discover_binary()
+    except BinaryDiscoveryError as exc:  # pragma: no cover - runtime safeguard
+        raise SystemExit(f"UniDesign binary could not be located: {exc}") from exc
+
+    runner = UniDesignRunner(binary)
+    mol2_path = (
+        project_root()
+        / "example/ProteinLigandInteraction/1r091_BS01_JEN/lig_charge.mol2"
+    )
+    if not mol2_path.is_file():
+        raise SystemExit(f"Example MOL2 file not found: {mol2_path}")
+
+    config = MakeLigParamConfig(
+        mol2_path=mol2_path,
+        ligand_parameter_path="example_LIG_PARAM.prm",
+        ligand_topology_path="example_LIG_TOPO.inp",
+    )
+
+    job = LigandParameterizationJob(runner, config)
+    result = job.run(keep_workspace=True)
+    try:
+        print("Parameter file:", result.parameter_file.path if result.parameter_file else "<missing>")
+        print("Topology file:", result.topology_file.path if result.topology_file else "<missing>")
+    finally:
+        result.close()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution hook
+    main()

--- a/examples/python/monomer_design.py
+++ b/examples/python/monomer_design.py
@@ -1,0 +1,49 @@
+"""Example script running a monomer-design trajectory via the Python wrapper."""
+
+from __future__ import annotations
+
+from unidesign import (
+    BinaryDiscoveryError,
+    ProteinDesignConfig,
+    UniDesignRunner,
+    discover_binary,
+)
+from unidesign.jobs import ProteinDesignJob
+from unidesign.paths import project_root
+
+
+def main() -> None:
+    try:
+        binary = discover_binary()
+    except BinaryDiscoveryError as exc:  # pragma: no cover - runtime safeguard
+        raise SystemExit(f"UniDesign binary could not be located: {exc}") from exc
+
+    runner = UniDesignRunner(binary)
+
+    pdb_path = project_root() / "example/MonomerDesign/1igd/1igd.pdb"
+    if not pdb_path.is_file():
+        raise SystemExit(f"Example PDB file not found: {pdb_path}")
+
+    config = ProteinDesignConfig(
+        pdb_path=pdb_path,
+        design_chains="A",
+        n_trajectories=1,
+        rotate_hydroxyl=True,
+    )
+
+    job = ProteinDesignJob(runner, config)
+    result = job.run(keep_workspace=False)
+
+    try:
+        print(f"Return code: {result.run.returncode}")
+        print(f"Prefix: {result.prefix}")
+        if result.best_structure:
+            print("Best structure:", result.best_structure.path)
+        if result.best_sequences:
+            print("Best sequences:", result.best_sequences.path)
+    finally:
+        result.close()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution hook
+    main()

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest fixtures for the UniDesign Python wrapper."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the ``unidesign`` package is importable when tests run from the
+# repository root without an installed wheel.
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))

--- a/python/tests/test_jobs.py
+++ b/python/tests/test_jobs.py
@@ -1,0 +1,160 @@
+"""Integration-style smoke tests for job helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from unidesign import (
+    ComputeBindingConfig,
+    ComputeStabilityConfig,
+    MakeLigParamConfig,
+    ProteinDesignConfig,
+)
+from unidesign.jobs import (
+    BindingComputationJob,
+    LigandParameterizationJob,
+    ProteinDesignJob,
+    StabilityComputationJob,
+)
+from unidesign.runner import UniDesignRunner
+
+
+@pytest.fixture
+def runner_with_fake_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Create a runner wired to a fake subprocess implementation."""
+
+    binary = tmp_path / "UniDesign"
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+
+    resources: list[tuple[str, Path]] = []
+    for name in ("library", "wread", "extbin"):
+        resource = tmp_path / f"resource_{name}"
+        resource.mkdir()
+        (resource / "placeholder.txt").write_text(name)
+        resources.append((name, resource))
+
+    monkeypatch.setattr(UniDesignRunner, "_STATIC_RESOURCES", tuple(resources))
+    runner = UniDesignRunner(binary)
+    calls: list[tuple[str | None, Path]] = []
+
+    def fake_run(argv, cwd, env, check, capture_output, text):
+        workdir = Path(cwd)
+        prefix = argv[argv.index("--prefix") + 1]
+        command = None
+        if "--command" in argv:
+            command = argv[argv.index("--command") + 1]
+
+        if command == "ProteinDesign":
+            (workdir / f"{prefix}_selfenergy.txt").write_text("energy")
+            (workdir / f"{prefix}_bestseqs").write_text("SEQ\n")
+            (workdir / f"{prefix}_beststruct").write_text("MODEL\n")
+        elif command == "ComputeStability":
+            (workdir / f"{prefix}_rotlist.txt").write_text("rotamer")
+        elif command == "MakeLigParamAndTopo":
+            param_path = Path(argv[argv.index("--lig_param") + 1])
+            topo_path = Path(argv[argv.index("--lig_topo") + 1])
+            (workdir / param_path).write_text("PARAMS")
+            (workdir / topo_path).write_text("TOPO")
+        # ComputeBinding does not write additional artefacts in this smoke test.
+
+        calls.append((command, workdir))
+        return subprocess.CompletedProcess(argv, 0, stdout=f"{command} stdout", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return runner, calls
+
+
+def _create_minimal_pdb(path: Path) -> None:
+    path.write_text(
+        "HEADER    TEST PDB\n"
+        "ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N\n"
+        "TER\n"
+        "END\n"
+    )
+
+
+def _create_minimal_mol2(path: Path) -> None:
+    path.write_text(
+        "@<TRIPOS>MOLECULE\n"
+        "LIG\n"
+        " 1 0 0 0 0\n"
+        "SMALL\n"
+        "NO_CHARGES\n"
+        "@<TRIPOS>ATOM\n"
+        "      1 C1         0.0    0.0    0.0 C.3       1 <0>        0.0000\n"
+        "@<TRIPOS>BOND\n"
+    )
+
+
+def test_protein_design_job_end_to_end(runner_with_fake_binary, tmp_path: Path):
+    runner, calls = runner_with_fake_binary
+
+    pdb_path = tmp_path / "input.pdb"
+    _create_minimal_pdb(pdb_path)
+    config = ProteinDesignConfig(pdb_path=pdb_path, design_chains="A", n_trajectories=1)
+
+    job = ProteinDesignJob(runner, config)
+    result = job.run()
+
+    try:
+        assert result.run.returncode == 0
+        assert result.self_energy is not None
+        assert result.self_energy.read_text() == "energy"
+        assert result.best_sequences is not None
+        assert "SEQ" in result.best_sequences.read_text()
+        assert result.best_structure is not None
+        assert result.best_structure.read_text().startswith("MODEL")
+        assert calls and calls[0][0] == "ProteinDesign"
+        original_workdir = calls[0][1]
+        assert not original_workdir.exists(), "Original workspace should be relocated"
+        assert result.workspace.exists()
+    finally:
+        result.close()
+        assert not result.workspace.exists()
+
+
+def test_energy_jobs_cover_rotamer_and_binding(runner_with_fake_binary, tmp_path: Path):
+    runner, calls = runner_with_fake_binary
+
+    pdb_path = tmp_path / "energy_input.pdb"
+    _create_minimal_pdb(pdb_path)
+
+    stability_job = StabilityComputationJob(runner, ComputeStabilityConfig(pdb_path=pdb_path))
+    stability_result = stability_job.run(keep_workspace=True)
+    try:
+        assert stability_result.rotamer_list is not None
+        assert stability_result.rotamer_list.read_text() == "rotamer"
+        assert calls and any(cmd == "ComputeStability" for cmd, _ in calls)
+    finally:
+        stability_result.close()
+
+    binding_job = BindingComputationJob(runner, ComputeBindingConfig(pdb_path=pdb_path))
+    binding_result = binding_job.run()
+    try:
+        assert binding_result.run.returncode == 0
+        assert any(cmd == "ComputeBinding" for cmd, _ in calls)
+    finally:
+        binding_result.close()
+
+
+def test_ligand_parameter_job_handles_outputs(runner_with_fake_binary, tmp_path: Path):
+    runner, calls = runner_with_fake_binary
+
+    mol2_path = tmp_path / "ligand.mol2"
+    _create_minimal_mol2(mol2_path)
+    config = MakeLigParamConfig(mol2_path=mol2_path)
+
+    job = LigandParameterizationJob(runner, config)
+    result = job.run()
+    try:
+        assert result.parameter_file is not None
+        assert result.parameter_file.read_text() == "PARAMS"
+        assert result.topology_file is not None
+        assert result.topology_file.read_text() == "TOPO"
+        assert any(cmd == "MakeLigParamAndTopo" for cmd, _ in calls)
+    finally:
+        result.close()

--- a/python/tests/test_runner.py
+++ b/python/tests/test_runner.py
@@ -1,0 +1,80 @@
+"""Tests covering :mod:`unidesign.runner`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from unidesign.runner import UniDesignRunner
+
+
+@pytest.fixture
+def dummy_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Return a dummy binary path and patch runner resources with lightweight data."""
+
+    binary = tmp_path / "UniDesign"
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+
+    resources: list[tuple[str, Path]] = []
+    for name in ("library", "wread", "extbin"):
+        resource_path = tmp_path / f"resource_{name}"
+        resource_path.mkdir()
+        (resource_path / "placeholder.txt").write_text(name)
+        resources.append((name, resource_path))
+
+    monkeypatch.setattr(UniDesignRunner, "_STATIC_RESOURCES", tuple(resources))
+    return binary, resources
+
+
+def test_runner_prepares_workspace(dummy_binary, monkeypatch: pytest.MonkeyPatch):
+    binary, resources = dummy_binary
+    captured: dict[str, object] = {}
+
+    def fake_run(argv, cwd, env, check, capture_output, text):
+        workdir = Path(cwd)
+        prefix = argv[argv.index("--prefix") + 1]
+        (workdir / f"{prefix}_marker.txt").write_text("marker")
+        captured.update({
+            "argv": tuple(argv),
+            "cwd": workdir,
+            "env": dict(env),
+            "prefix": prefix,
+        })
+        return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    runner = UniDesignRunner(binary, default_env={"DEFAULT": "1"})
+    result = runner.run(["--command", "Smoke"], env={"EXTRA": "2"}, persist_workdir=True)
+
+    assert captured["argv"][:3] == (str(binary), "--prefix", result.prefix)
+    assert result.args[0] == "--prefix"
+    assert result.args[1] == captured["prefix"]
+    assert result.stdout == "ok"
+    assert result.stderr == ""
+    assert result.workdir == captured["cwd"]
+    assert (result.workdir / f"{result.prefix}_marker.txt").read_text() == "marker"
+
+    for name, _ in resources:
+        assert (result.workdir / name).exists()
+
+    assert captured["env"]["DEFAULT"] == "1"
+    assert captured["env"]["EXTRA"] == "2"
+
+
+def test_runner_cleans_workspace_by_default(dummy_binary, monkeypatch: pytest.MonkeyPatch):
+    binary, _ = dummy_binary
+
+    def fake_run(argv, cwd, env, check, capture_output, text):
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    runner = UniDesignRunner(binary)
+    result = runner.run(["--command", "Smoke"])
+
+    assert result.returncode == 0
+    assert not result.workdir.exists(), "Temporary workspace should be removed when not persisted"

--- a/python/unidesign/runner.py
+++ b/python/unidesign/runner.py
@@ -8,8 +8,8 @@ import subprocess
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Mapping, MutableMapping, Sequence
+from tempfile import TemporaryDirectory, mkdtemp
+from typing import Mapping, MutableMapping, Protocol, Sequence
 
 from . import paths
 
@@ -35,6 +35,23 @@ class UniDesignRunResult:
 
     prefix: str
     """Prefix automatically injected into CLI arguments for unique output names."""
+
+
+class _TempDirLike(Protocol):
+    name: str
+
+    def cleanup(self) -> None:
+        ...
+
+
+class _PersistentTempDir:
+    """No-op cleanup manager for persisted working directories."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def cleanup(self) -> None:  # pragma: no cover - nothing to clean
+        return None
 
 
 class UniDesignRunner:
@@ -82,12 +99,14 @@ class UniDesignRunner:
             else:
                 shutil.copy2(source, target)
 
-    def _prepare_workdir(self, persist: bool) -> tuple[TemporaryDirectory, Path]:
-        tmp_dir = TemporaryDirectory(
-            prefix="unidesign_",
-            dir=str(self._base_working_dir) if self._base_working_dir else None,
-            delete=not persist,
-        )
+    def _prepare_workdir(self, persist: bool) -> tuple[_TempDirLike, Path]:
+        base_dir = str(self._base_working_dir) if self._base_working_dir else None
+        if persist:
+            tmp_dir: _TempDirLike = _PersistentTempDir(
+                mkdtemp(prefix="unidesign_", dir=base_dir)
+            )
+        else:
+            tmp_dir = TemporaryDirectory(prefix="unidesign_", dir=base_dir)
         workdir = Path(tmp_dir.name)
         for name, source in self._STATIC_RESOURCES:
             self._ensure_resource(workdir, name, source)


### PR DESCRIPTION
## Summary
- add Sphinx-based documentation describing setup, command usage, workspace handling, and persistence options for the Python wrapper
- provide runnable Python examples for design, energy scoring, and ligand parameter generation against the bundled sample data
- create pytest smoke tests for the wrapper APIs and wire them, together with a Sphinx build, into a dedicated GitHub Actions workflow

## Testing
- pytest python/tests


------
https://chatgpt.com/codex/tasks/task_e_68d6a070f77483288266a1a0cd5fc7cf