### PR TITLE
Add BuildMutant job wrapper

### DIFF
--- a/python/tests/test_jobs.py
+++ b/python/tests/test_jobs.py
@@ -8,6 +8,7 @@ import subprocess
 import pytest
 
 from unidesign import (
+    BuildMutantConfig,
     ComputeBindingConfig,
     ComputeStabilityConfig,
     MakeLigParamConfig,
@@ -16,6 +17,7 @@ from unidesign import (
 from unidesign.jobs import (
     BindingComputationJob,
     LigandParameterizationJob,
+    MutantModelingJob,
     ProteinDesignJob,
     StabilityComputationJob,
 )
@@ -59,6 +61,18 @@ def runner_with_fake_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             topo_path = Path(argv[argv.index("--lig_topo") + 1])
             (workdir / param_path).write_text("PARAMS")
             (workdir / topo_path).write_text("TOPO")
+        elif command == "BuildMutant":
+            mutant_file = Path(argv[argv.index("--mutant_file") + 1])
+            definitions = [
+                line for line in mutant_file.read_text().splitlines() if line.strip()
+            ]
+            for idx, _ in enumerate(definitions, start=1):
+                (workdir / f"{prefix}_Model_{idx:04d}.pdb").write_text(
+                    f"MODEL {idx}\n"
+                )
+                (workdir / f"{prefix}_Model_{idx:04d}_WT.pdb").write_text(
+                    f"WT {idx}\n"
+                )
         # ComputeBinding does not write additional artefacts in this smoke test.
 
         calls.append((command, workdir))
@@ -156,5 +170,29 @@ def test_ligand_parameter_job_handles_outputs(runner_with_fake_binary, tmp_path:
         assert result.topology_file is not None
         assert result.topology_file.read_text() == "TOPO"
         assert any(cmd == "MakeLigParamAndTopo" for cmd, _ in calls)
+    finally:
+        result.close()
+
+
+def test_mutant_modeling_job_produces_models(runner_with_fake_binary, tmp_path: Path):
+    runner, calls = runner_with_fake_binary
+
+    pdb_path = tmp_path / "mutant_input.pdb"
+    _create_minimal_pdb(pdb_path)
+    config = BuildMutantConfig(
+        pdb_path=pdb_path,
+        mutants=[{"A": ["H18F", "Q22D"]}, {"A": "QA22D", "B": ["M20A"]}],
+    )
+
+    job = MutantModelingJob(runner, config)
+    result = job.run()
+    try:
+        assert result.run.returncode == 0
+        assert len(result.mutant_models) == 2
+        assert result.mutant_models[0].mutant_index == 1
+        assert result.mutant_models[0].read_text().startswith("MODEL")
+        assert any(cmd == "BuildMutant" for cmd, _ in calls)
+        original_workdir = next(work for cmd, work in calls if cmd == "BuildMutant")
+        assert not original_workdir.exists()
     finally:
         result.close()

--- a/python/unidesign/__init__.py
+++ b/python/unidesign/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .config import (
+    BuildMutantConfig,
     CommandConfig,
     ComputeBindingConfig,
     ComputeStabilityConfig,
@@ -15,6 +16,8 @@ from .jobs import (
     BindingComputationResult,
     LigandParameterizationJob,
     LigandParameterizationResult,
+    MutantModelingJob,
+    MutantModelingResult,
     ProteinDesignJob,
     ProteinDesignResult,
     StabilityComputationJob,
@@ -34,6 +37,7 @@ __all__ = [
     "ComputeStabilityConfig",
     "ComputeBindingConfig",
     "MakeLigParamConfig",
+    "BuildMutantConfig",
     "ProteinDesignJob",
     "ProteinDesignResult",
     "StabilityComputationJob",
@@ -42,4 +46,6 @@ __all__ = [
     "BindingComputationResult",
     "LigandParameterizationJob",
     "LigandParameterizationResult",
+    "MutantModelingJob",
+    "MutantModelingResult",
 ]

--- a/python/unidesign/artifacts.py
+++ b/python/unidesign/artifacts.py
@@ -152,6 +152,17 @@ class LigandTopology(UniDesignArtifact):
         return super().default_filename()
 
 
+@dataclass(slots=True)
+class MutantStructureModel(UniDesignArtifact):
+    """PDB structure corresponding to a generated mutant."""
+
+    mutant_index: int
+
+    def __post_init__(self) -> None:
+        if self.mutant_index <= 0:
+            raise ValueError("mutant_index must be positive")
+
+
 __all__ = [
     "UniDesignArtifact",
     "SelfEnergyReport",
@@ -163,4 +174,5 @@ __all__ = [
     "LigandPoseEnsemble",
     "LigandParameters",
     "LigandTopology",
+    "MutantStructureModel",
 ]

--- a/python/unidesign/config.py
+++ b/python/unidesign/config.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Literal, Protocol, Sequence
+import re
+from typing import Iterable, Literal, Mapping, Protocol, Sequence
 
 
 def _as_path(value: str | Path) -> str:
@@ -325,6 +326,60 @@ def _normalise_atom_triplet(atoms: Sequence[str]) -> tuple[str, str, str]:
     return tuple(atoms)  # type: ignore[return-value]
 
 
+_MUTATION_WITH_CHAIN = re.compile(r"^(?P<from>[A-Za-z])(?P<chain>[A-Za-z])(?P<pos>\d+)(?P<to>[A-Za-z])$")
+_MUTATION_WITHOUT_CHAIN = re.compile(r"^(?P<from>[A-Za-z])(?P<pos>\d+)(?P<to>[A-Za-z])$")
+
+
+def _normalise_single_mutation(chain: str, mutation: str) -> str:
+    token = mutation.strip().rstrip(";")
+    if not token:
+        raise ValueError("Mutation entries must not be empty")
+
+    match = _MUTATION_WITH_CHAIN.fullmatch(token)
+    if match:
+        parsed_chain = match.group("chain").upper()
+        expected_chain = chain.upper()
+        if parsed_chain != expected_chain:
+            raise ValueError(
+                f"Mutation '{token}' does not match declared chain '{chain}'"
+            )
+        return (
+            f"{match.group('from').upper()}{parsed_chain}"
+            f"{match.group('pos')}{match.group('to').upper()}"
+        )
+
+    match = _MUTATION_WITHOUT_CHAIN.fullmatch(token)
+    if match:
+        if not chain:
+            raise ValueError(
+                "Chain identifier must be provided when mutation omits the chain"
+            )
+        parsed_chain = chain.upper()
+        return (
+            f"{match.group('from').upper()}{parsed_chain}"
+            f"{match.group('pos')}{match.group('to').upper()}"
+        )
+
+    raise ValueError(
+        "Mutation entries must follow the FoldX convention: "
+        "{orig}{chain}{position}{mutant}"
+    )
+
+
+def _format_mutant_entry(mutant: Mapping[str, Sequence[str] | str]) -> str:
+    entries: list[str] = []
+    for chain, raw_mutations in mutant.items():
+        if isinstance(raw_mutations, str):
+            values = [raw_mutations]
+        else:
+            values = list(raw_mutations)
+        for mutation in values:
+            entries.append(_normalise_single_mutation(chain, mutation))
+    if not entries:
+        raise ValueError("Each mutant specification must contain at least one mutation")
+    return ",".join(entries) + ";"
+
+
 @dataclass(slots=True)
 class MakeLigParamConfig:
     """Configuration for the ``MakeLigParamAndTopo`` command.
@@ -366,11 +421,72 @@ class MakeLigParamConfig:
         ]
 
 
+@dataclass(slots=True)
+class BuildMutantConfig:
+    """Configuration for the ``BuildMutant`` command."""
+
+    pdb_path: str | Path
+    """Input structure supplied through ``--pdb``."""
+
+    mutants: Sequence[Mapping[str, Sequence[str] | str]]
+    """Structured mutant definitions grouped by chain identifier."""
+
+    use_bbdep_rotlib: bool | None = None
+    """Optional override for ``--bbdep`` (defaults to backbone-dependent rotamers)."""
+
+    rotamer_library: str | None = None
+    """Backbone-independent library name forwarded via ``--rotlib`` when provided."""
+
+    weight_file: str | Path | None = None
+    """Energy weight override for ``--wread`` (defaults to ``wread/weight_all1.wgt``)."""
+
+    max_optimisation_runs: int | None = None
+    """Number of optimisation iterations supplied through ``--num_of_runs``."""
+
+    mutant_file_path: str | Path | None = None
+    """Path to the generated mutant definition file consumed via ``--mutant_file``."""
+
+    def mutant_file_contents(self) -> str:
+        """Render the mutant specification file expected by UniDesign."""
+
+        lines = [_format_mutant_entry(mutant) for mutant in self.mutants]
+        return "\n".join(lines) + ("\n" if lines else "")
+
+    def to_cli_args(self) -> list[str]:
+        if self.mutant_file_path is None:
+            raise ValueError(
+                "mutant_file_path must be set before rendering CLI arguments"
+            )
+
+        args: list[str] = [
+            "--command",
+            "BuildMutant",
+            "--pdb",
+            _as_path(self.pdb_path),
+            "--mutant_file",
+            _as_path(self.mutant_file_path),
+        ]
+
+        if self.use_bbdep_rotlib is not None:
+            args.extend(("--bbdep", _format_bool(self.use_bbdep_rotlib)))
+        if self.rotamer_library is not None:
+            args.extend(("--rotlib", self.rotamer_library))
+        if self.weight_file is not None:
+            args.extend(("--wread", _as_path(self.weight_file)))
+        if self.max_optimisation_runs is not None:
+            if self.max_optimisation_runs <= 0:
+                raise ValueError("max_optimisation_runs must be positive")
+            args.extend(("--num_of_runs", str(self.max_optimisation_runs)))
+
+        return args
+
+
 __all__ = [
     "CommandConfig",
     "ProteinDesignConfig",
     "ComputeStabilityConfig",
     "ComputeBindingConfig",
     "MakeLigParamConfig",
+    "BuildMutantConfig",
 ]
 

--- a/python/unidesign/jobs/__init__.py
+++ b/python/unidesign/jobs/__init__.py
@@ -8,6 +8,7 @@ from .energy import (
     StabilityComputationResult,
 )
 from .ligand import LigandParameterizationJob, LigandParameterizationResult
+from .mutant import MutantModelingJob, MutantModelingResult
 
 __all__ = [
     "ProteinDesignJob",
@@ -18,4 +19,6 @@ __all__ = [
     "BindingComputationResult",
     "LigandParameterizationJob",
     "LigandParameterizationResult",
+    "MutantModelingJob",
+    "MutantModelingResult",
 ]

--- a/python/unidesign/jobs/mutant.py
+++ b/python/unidesign/jobs/mutant.py
@@ -1,0 +1,131 @@
+"""Mutant modelling job wrappers."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Callable, Mapping
+
+from ..artifacts import MutantStructureModel
+from ..config import BuildMutantConfig
+from ..runner import UniDesignRunner, UniDesignRunResult
+
+
+def _discover_mutant_models(workdir: Path) -> list[Path]:
+    """Return potential mutant PDB files emitted by UniDesign."""
+
+    candidates = [
+        path
+        for path in workdir.rglob("*.pdb")
+        if "Model_" in path.name and not path.name.endswith("_WT.pdb")
+    ]
+    candidates.sort()
+    return candidates
+
+
+def _relocate_mutant_models(
+    workdir: Path,
+    *,
+    prefix: str,
+    keep_workspace: bool,
+) -> tuple[Path, list[MutantStructureModel], Callable[[], None]]:
+    """Relocate mutant models respecting caller workspace preferences."""
+
+    models = _discover_mutant_models(workdir)
+
+    if keep_workspace:
+        artifacts = [
+            MutantStructureModel(
+                path=path,
+                prefix=prefix,
+                logical_name=f"mutant_model_{index}",
+                mutant_index=index,
+            )
+            for index, path in enumerate(models, start=1)
+        ]
+        cleanup = lambda: shutil.rmtree(workdir, ignore_errors=True)
+        return workdir, artifacts, cleanup
+
+    destination = Path(tempfile.mkdtemp(prefix="unidesign_artifacts_"))
+
+    relocated: list[MutantStructureModel] = []
+    for index, source in enumerate(models, start=1):
+        try:
+            relative = source.relative_to(workdir)
+        except ValueError:
+            relative = Path(source.name)
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+        relocated.append(
+            MutantStructureModel(
+                path=target,
+                prefix=prefix,
+                logical_name=f"mutant_model_{index}",
+                mutant_index=index,
+            )
+        )
+
+    shutil.rmtree(workdir, ignore_errors=True)
+
+    def _cleanup() -> None:
+        shutil.rmtree(destination, ignore_errors=True)
+
+    return destination, relocated, _cleanup
+
+
+@dataclass(slots=True)
+class MutantModelingResult:
+    """Encapsulates outputs for ``BuildMutant`` runs."""
+
+    run: UniDesignRunResult
+    workspace: Path
+    mutant_models: tuple[MutantStructureModel, ...]
+    cleanup: Callable[[], None] | None
+
+    def close(self) -> None:
+        if self.cleanup is not None:
+            self.cleanup()
+            self.cleanup = None
+
+
+class MutantModelingJob:
+    """Execute the ``BuildMutant`` command with structured inputs."""
+
+    def __init__(self, runner: UniDesignRunner, config: BuildMutantConfig) -> None:
+        self._runner = runner
+        self._config = config
+
+    def run(
+        self,
+        *,
+        keep_workspace: bool = False,
+        env: Mapping[str, str] | None = None,
+    ) -> MutantModelingResult:
+        with TemporaryDirectory(prefix="unidesign_mutants_") as tmp_dir:
+            mutant_file = Path(tmp_dir) / "mutants.txt"
+            mutant_file.write_text(self._config.mutant_file_contents())
+            config = replace(self._config, mutant_file_path=mutant_file)
+            run_result = self._runner.run(
+                config.to_cli_args(), env=env, persist_workdir=True
+            )
+
+        workspace, models, cleanup = _relocate_mutant_models(
+            run_result.workdir,
+            prefix=run_result.prefix,
+            keep_workspace=keep_workspace,
+        )
+        run_result.workdir = workspace
+
+        return MutantModelingResult(
+            run=run_result,
+            workspace=workspace,
+            mutant_models=tuple(models),
+            cleanup=cleanup,
+        )
+
+
+__all__ = ["MutantModelingJob", "MutantModelingResult"]


### PR DESCRIPTION
## Summary
- add a BuildMutantConfig helper that formats structured mutant specifications for the CLI
- implement MutantModelingJob with artifact handling for generated mutant models
- extend the smoke tests to cover the BuildMutant workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da50a0cbf8832889acc0b4fbbc01cd