### PR TITLE
Add job wrapper for BuildMutant command

### DIFF
--- a/python/tests/test_jobs.py
+++ b/python/tests/test_jobs.py
@@ -8,6 +8,7 @@ import subprocess
 import pytest
 
 from unidesign import (
+    BuildMutantConfig,
     ComputeBindingConfig,
     ComputeStabilityConfig,
     MakeLigParamConfig,
@@ -16,6 +17,7 @@ from unidesign import (
 from unidesign.jobs import (
     BindingComputationJob,
     LigandParameterizationJob,
+    MutantStructureBuildJob,
     ProteinDesignJob,
     StabilityComputationJob,
 )
@@ -39,7 +41,7 @@ def runner_with_fake_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(UniDesignRunner, "_STATIC_RESOURCES", tuple(resources))
     runner = UniDesignRunner(binary)
-    calls: list[tuple[str | None, Path]] = []
+    calls: list[tuple[str | None, Path, dict[str, object]]] = []
 
     def fake_run(argv, cwd, env, check, capture_output, text):
         workdir = Path(cwd)
@@ -47,6 +49,8 @@ def runner_with_fake_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         command = None
         if "--command" in argv:
             command = argv[argv.index("--command") + 1]
+
+        metadata: dict[str, object] = {}
 
         if command == "ProteinDesign":
             (workdir / f"{prefix}_selfenergy.txt").write_text("energy")
@@ -59,9 +63,20 @@ def runner_with_fake_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             topo_path = Path(argv[argv.index("--lig_topo") + 1])
             (workdir / param_path).write_text("PARAMS")
             (workdir / topo_path).write_text("TOPO")
+        elif command == "BuildMutant":
+            pdb_path = Path(argv[argv.index("--pdb") + 1])
+            mutant_file = Path(argv[argv.index("--mutant_file") + 1])
+            lines = mutant_file.read_text(encoding="utf-8").splitlines()
+            metadata["mutant_lines"] = lines
+            generated: list[str] = []
+            for index, _ in enumerate(lines, start=1):
+                filename = f"{pdb_path.stem}_Model_{index:04d}.pdb"
+                (workdir / filename).write_text(f"MODEL {index}\n")
+                generated.append(filename)
+            metadata["generated_files"] = generated
         # ComputeBinding does not write additional artefacts in this smoke test.
 
-        calls.append((command, workdir))
+        calls.append((command, workdir, metadata))
         return subprocess.CompletedProcess(argv, 0, stdout=f"{command} stdout", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -128,7 +143,7 @@ def test_energy_jobs_cover_rotamer_and_binding(runner_with_fake_binary, tmp_path
     try:
         assert stability_result.rotamer_list is not None
         assert stability_result.rotamer_list.read_text() == "rotamer"
-        assert calls and any(cmd == "ComputeStability" for cmd, _ in calls)
+        assert calls and any(entry[0] == "ComputeStability" for entry in calls)
     finally:
         stability_result.close()
 
@@ -136,9 +151,53 @@ def test_energy_jobs_cover_rotamer_and_binding(runner_with_fake_binary, tmp_path
     binding_result = binding_job.run()
     try:
         assert binding_result.run.returncode == 0
-        assert any(cmd == "ComputeBinding" for cmd, _ in calls)
+        assert any(entry[0] == "ComputeBinding" for entry in calls)
     finally:
         binding_result.close()
+
+
+def test_mutant_structure_job_generates_named_models(
+    runner_with_fake_binary, tmp_path: Path
+):
+    runner, calls = runner_with_fake_binary
+
+    pdb_path = tmp_path / "mutant_input.pdb"
+    _create_minimal_pdb(pdb_path)
+
+    config = BuildMutantConfig(pdb_path=pdb_path)
+    job = MutantStructureBuildJob(runner, config)
+    mutants = [
+        {"A": "Q22D"},
+        {"A": ["H18F", "Q22D"]},
+        {"A": ["H18F"], "B": ["M20A"]},
+    ]
+
+    result = job.run(mutants)
+    try:
+        expected_labels = ["QA22D", "HA18F,QA22D", "HA18F,MB20A"]
+        assert list(result.mutant_models.keys()) == expected_labels
+        expected_files = {
+            "QA22D": "QA22D.pdb",
+            "HA18F,QA22D": "HA18F_QA22D.pdb",
+            "HA18F,MB20A": "HA18F_MB20A.pdb",
+        }
+        assert {
+            label: artifact.path.name for label, artifact in result.mutant_models.items()
+        } == expected_files
+
+        command, _, metadata = next(entry for entry in calls if entry[0] == "BuildMutant")
+        assert command == "BuildMutant"
+        assert metadata.get("mutant_lines") == [f"{label};" for label in expected_labels]
+        assert metadata.get("generated_files") == [
+            f"{pdb_path.stem}_Model_{index:04d}.pdb" for index in range(1, 4)
+        ]
+
+        for artifact in result.mutant_models.values():
+            assert artifact.path.exists()
+            assert artifact.path.parent == result.workspace
+    finally:
+        result.close()
+        assert not result.workspace.exists()
 
 
 def test_ligand_parameter_job_handles_outputs(runner_with_fake_binary, tmp_path: Path):
@@ -155,6 +214,6 @@ def test_ligand_parameter_job_handles_outputs(runner_with_fake_binary, tmp_path:
         assert result.parameter_file.read_text() == "PARAMS"
         assert result.topology_file is not None
         assert result.topology_file.read_text() == "TOPO"
-        assert any(cmd == "MakeLigParamAndTopo" for cmd, _ in calls)
+        assert any(entry[0] == "MakeLigParamAndTopo" for entry in calls)
     finally:
         result.close()

--- a/python/unidesign/__init__.py
+++ b/python/unidesign/__init__.py
@@ -7,6 +7,7 @@ from .config import (
     ComputeBindingConfig,
     ComputeStabilityConfig,
     MakeLigParamConfig,
+    BuildMutantConfig,
     ProteinDesignConfig,
 )
 from .exceptions import BinaryDiscoveryError, UniDesignError
@@ -15,6 +16,8 @@ from .jobs import (
     BindingComputationResult,
     LigandParameterizationJob,
     LigandParameterizationResult,
+    MutantStructureBuildJob,
+    MutantStructureBuildResult,
     ProteinDesignJob,
     ProteinDesignResult,
     StabilityComputationJob,
@@ -31,6 +34,7 @@ __all__ = [
     "UniDesignRunResult",
     "CommandConfig",
     "ProteinDesignConfig",
+    "BuildMutantConfig",
     "ComputeStabilityConfig",
     "ComputeBindingConfig",
     "MakeLigParamConfig",
@@ -42,4 +46,6 @@ __all__ = [
     "BindingComputationResult",
     "LigandParameterizationJob",
     "LigandParameterizationResult",
+    "MutantStructureBuildJob",
+    "MutantStructureBuildResult",
 ]

--- a/python/unidesign/config.py
+++ b/python/unidesign/config.py
@@ -251,6 +251,34 @@ class ProteinDesignConfig:
 
 
 @dataclass(slots=True)
+class BuildMutantConfig:
+    """Configuration for the ``BuildMutant`` command.
+
+    The command expects an input structure provided through ``--pdb`` and a mutant
+    manifest supplied via ``--mutant_file``. The job helper automatically writes the
+    manifest when operating on structured mutation specifications.
+    """
+
+    pdb_path: str | Path
+    """Path to the input structure passed via ``--pdb``."""
+
+    mutant_file: str | Path | None = None
+    """Path to the mutant specification forwarded with ``--mutant_file``."""
+
+    def to_cli_args(self) -> list[str]:
+        if self.mutant_file is None:
+            raise ValueError("mutant_file must be provided before generating CLI arguments")
+        return [
+            "--command",
+            "BuildMutant",
+            "--pdb",
+            _as_path(self.pdb_path),
+            "--mutant_file",
+            _as_path(self.mutant_file),
+        ]
+
+
+@dataclass(slots=True)
 class ComputeStabilityConfig:
     """Configuration for the ``ComputeStability`` command.
 
@@ -369,6 +397,7 @@ class MakeLigParamConfig:
 __all__ = [
     "CommandConfig",
     "ProteinDesignConfig",
+    "BuildMutantConfig",
     "ComputeStabilityConfig",
     "ComputeBindingConfig",
     "MakeLigParamConfig",

--- a/python/unidesign/jobs/__init__.py
+++ b/python/unidesign/jobs/__init__.py
@@ -8,6 +8,7 @@ from .energy import (
     StabilityComputationResult,
 )
 from .ligand import LigandParameterizationJob, LigandParameterizationResult
+from .mutant import MutantStructureBuildJob, MutantStructureBuildResult
 
 __all__ = [
     "ProteinDesignJob",
@@ -18,4 +19,6 @@ __all__ = [
     "BindingComputationResult",
     "LigandParameterizationJob",
     "LigandParameterizationResult",
+    "MutantStructureBuildJob",
+    "MutantStructureBuildResult",
 ]

--- a/python/unidesign/jobs/mutant.py
+++ b/python/unidesign/jobs/mutant.py
@@ -1,0 +1,219 @@
+"""Mutant structure modelling job wrappers."""
+
+from __future__ import annotations
+
+import re
+import tempfile
+from collections.abc import Mapping as MappingCollection
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Callable, Mapping
+
+from ..artifacts import StructureModel
+from ..config import BuildMutantConfig
+from ..runner import UniDesignRunResult, UniDesignRunner
+from ._shared import ArtifactSpec, relocate_artifacts
+
+MutationValue = str | Sequence[str]
+"""Accepted value types describing a mutation for a specific chain."""
+
+MutantSpecification = MappingCollection[str, MutationValue]
+"""Mapping between chain identifiers and mutation descriptors."""
+
+_WITH_CHAIN_PATTERN = re.compile(
+    r"^(?P<native>[A-Za-z])(?P<chain>[A-Za-z])(?P<position>\d+)(?P<mutant>[A-Za-z])$"
+)
+_WITHOUT_CHAIN_PATTERN = re.compile(
+    r"^(?P<native>[A-Za-z])(?P<position>\d+)(?P<mutant>[A-Za-z])$"
+)
+_SANITISE_PATTERN = re.compile(r"[^0-9A-Za-z]+")
+
+
+def _normalise_chain_id(chain_id: str) -> str:
+    chain = chain_id.strip()
+    if len(chain) != 1 or not chain.isalnum():
+        raise ValueError(f"Invalid chain identifier: {chain_id!r}")
+    return chain.upper()
+
+
+def _coerce_mutation_values(value: MutationValue) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence):
+        return [str(item) for item in value]
+    raise TypeError(f"Unsupported mutation descriptor type: {type(value)!r}")
+
+
+def _parse_mutation_descriptor(chain_id: str, descriptor: str) -> str:
+    cleaned = descriptor.strip()
+    if not cleaned:
+        raise ValueError("Mutation descriptor cannot be empty")
+
+    match = _WITH_CHAIN_PATTERN.match(cleaned)
+    if match:
+        native = match.group("native").upper()
+        chain = match.group("chain").upper()
+        position = match.group("position")
+        mutant = match.group("mutant").upper()
+        if chain != chain_id:
+            raise ValueError(
+                "Chain identifier mismatch between dictionary key and mutation descriptor"
+            )
+        return f"{native}{chain}{position}{mutant}"
+
+    match = _WITHOUT_CHAIN_PATTERN.match(cleaned)
+    if match:
+        native = match.group("native").upper()
+        position = match.group("position")
+        mutant = match.group("mutant").upper()
+        return f"{native}{chain_id}{position}{mutant}"
+
+    raise ValueError(f"Invalid mutation descriptor: {descriptor!r}")
+
+
+def _serialise_mutants(
+    mutants: Sequence[MutantSpecification],
+) -> tuple[list[str], list[str]]:
+    if not mutants:
+        raise ValueError("At least one mutant must be specified")
+
+    manifest_lines: list[str] = []
+    labels: list[str] = []
+
+    for specification in mutants:
+        if not specification:
+            raise ValueError("Mutation specification entries cannot be empty")
+
+        components: list[str] = []
+        for chain_id, descriptor in specification.items():
+            normalised_chain = _normalise_chain_id(str(chain_id))
+            for value in _coerce_mutation_values(descriptor):
+                components.append(_parse_mutation_descriptor(normalised_chain, value))
+
+        if not components:
+            raise ValueError("Mutation specification must include at least one substitution")
+
+        label = ",".join(components)
+        manifest_lines.append(f"{label};")
+        labels.append(label)
+
+    return manifest_lines, labels
+
+
+def _write_mutant_manifest(mutants: Sequence[MutantSpecification]) -> tuple[Path, list[str]]:
+    manifest_lines, labels = _serialise_mutants(mutants)
+    with tempfile.NamedTemporaryFile(
+        "w", prefix="unidesign_mutants_", suffix=".txt", delete=False, encoding="utf-8"
+    ) as handle:
+        handle.write("\n".join(manifest_lines))
+        manifest_path = Path(handle.name)
+    return manifest_path, labels
+
+
+def _sanitise_label(label: str) -> str:
+    sanitised = _SANITISE_PATTERN.sub("_", label).strip("_")
+    return sanitised or "mutant"
+
+
+def _unique_label(base: str, used: set[str], index: int) -> str:
+    candidate = base or f"mutant_{index}"
+    if candidate not in used:
+        return candidate
+    suffix = 2
+    while f"{candidate}_{suffix}" in used:
+        suffix += 1
+    return f"{candidate}_{suffix}"
+
+
+@dataclass(slots=True)
+class MutantStructureBuildResult:
+    """Bundle representing outputs from :class:`MutantStructureBuildJob`."""
+
+    run: UniDesignRunResult
+    workspace: Path
+    mutant_models: dict[str, StructureModel]
+    cleanup: Callable[[], None] | None
+
+    def close(self) -> None:
+        if self.cleanup is not None:
+            self.cleanup()
+            self.cleanup = None
+
+
+class MutantStructureBuildJob:
+    """Execute the ``BuildMutant`` command with structured mutation inputs."""
+
+    def __init__(self, runner: UniDesignRunner, config: BuildMutantConfig) -> None:
+        self._runner = runner
+        self._config = config
+
+    def run(
+        self,
+        mutants: Sequence[MutantSpecification],
+        *,
+        keep_workspace: bool = False,
+        env: Mapping[str, str] | None = None,
+    ) -> MutantStructureBuildResult:
+        manifest_path, labels = _write_mutant_manifest(mutants)
+        config = replace(self._config, mutant_file=manifest_path)
+
+        try:
+            run_result = self._runner.run(
+                config.to_cli_args(), env=env, persist_workdir=True
+            )
+        finally:
+            manifest_path.unlink(missing_ok=True)
+
+        pdb_stem = Path(config.pdb_path).stem
+        candidates: dict[str, ArtifactSpec] = {}
+        for index, label in enumerate(labels, start=1):
+            expected_name = f"{pdb_stem}_Model_{index:04d}.pdb"
+            sanitised = _sanitise_label(label)
+
+            def factory(path: Path, prefix: str, logical_name: str, *, _sanitised=sanitised) -> StructureModel:
+                return StructureModel(path=path, prefix=prefix, logical_name=_sanitised)
+
+            candidates[label] = ArtifactSpec(relative_path=Path(expected_name), factory=factory)
+
+        workspace, artifacts, cleanup = relocate_artifacts(
+            run_result.workdir,
+            candidates,
+            keep_workspace=keep_workspace,
+            prefix=run_result.prefix,
+        )
+        run_result.workdir = workspace
+
+        missing = [label for label in labels if label not in artifacts]
+        if missing:
+            if not keep_workspace:
+                cleanup()
+            raise FileNotFoundError(
+                "Expected mutant model(s) not produced: " + ", ".join(missing)
+            )
+
+        used_names: set[str] = set()
+        mutant_models: dict[str, StructureModel] = {}
+
+        for index, label in enumerate(labels, start=1):
+            artifact = artifacts[label]
+            base_name = _unique_label(_sanitise_label(label), used_names, index)
+            used_names.add(base_name)
+            target_name = f"{base_name}.pdb"
+            target_path = artifact.path.with_name(target_name)
+            if artifact.path.name != target_name:
+                artifact.path.rename(target_path)
+                artifact.path = target_path
+            artifact.logical_name = base_name
+            mutant_models[label] = artifact
+
+        return MutantStructureBuildResult(
+            run=run_result,
+            workspace=workspace,
+            mutant_models=mutant_models,
+            cleanup=cleanup,
+        )
+
+
+__all__ = ["MutantStructureBuildJob", "MutantStructureBuildResult"]
+


### PR DESCRIPTION
## Summary
- add a BuildMutantConfig for rendering the CLI arguments required by the BuildMutant command
- implement a MutantStructureBuildJob that accepts structured mutation specifications, writes the manifest, and renames outputs by mutation
- expose the new configuration and job, and extend the job smoke tests to cover the BuildMutant workflow

## Testing
- pytest python/tests/test_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68da3ff6ed0c83288b54142ac3c4b1c0