### PR TITLE
Add RESFILE helper classes to Python wrapper

### DIFF
--- a/python/tests/test_jobs.py
+++ b/python/tests/test_jobs.py
@@ -13,6 +13,8 @@ from unidesign import (
     ComputeStabilityConfig,
     MakeLigParamConfig,
     ProteinDesignConfig,
+    Resfile,
+    ResfileEntry,
 )
 from unidesign.jobs import (
     BindingComputationJob,
@@ -56,6 +58,10 @@ def runner_with_fake_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             (workdir / f"{prefix}_selfenergy.txt").write_text("energy")
             (workdir / f"{prefix}_bestseqs").write_text("SEQ\n")
             (workdir / f"{prefix}_beststruct").write_text("MODEL\n")
+            if "--resfile" in argv:
+                resfile_path = Path(argv[argv.index("--resfile") + 1])
+                metadata["resfile_path"] = resfile_path
+                metadata["resfile_contents"] = resfile_path.read_text(encoding="utf-8")
         elif command == "ComputeStability":
             (workdir / f"{prefix}_rotlist.txt").write_text("rotamer")
         elif command == "MakeLigParamAndTopo":
@@ -131,6 +137,31 @@ def test_protein_design_job_end_to_end(runner_with_fake_binary, tmp_path: Path):
     finally:
         result.close()
         assert not result.workspace.exists()
+
+
+def test_protein_design_job_writes_resfile(runner_with_fake_binary, tmp_path: Path):
+    runner, calls = runner_with_fake_binary
+
+    pdb_path = tmp_path / "resfile_input.pdb"
+    _create_minimal_pdb(pdb_path)
+    resfile = Resfile(
+        design=(ResfileEntry("A", 1, "AC"),),
+        repack=(ResfileEntry("A", 2),),
+        catalytic=(ResfileEntry("A", 3, ("S", "T")),),
+    )
+
+    config = ProteinDesignConfig(pdb_path=pdb_path, design_chains="A", resfile_path=resfile)
+    job = ProteinDesignJob(runner, config)
+    result = job.run()
+
+    try:
+        metadata = next(entry[2] for entry in calls if entry[0] == "ProteinDesign")
+        resfile_path = metadata.get("resfile_path")
+        assert resfile_path is not None
+        assert metadata.get("resfile_contents") == resfile.to_text()
+        assert not Path(resfile_path).exists()
+    finally:
+        result.close()
 
 
 def test_energy_jobs_cover_rotamer_and_binding(runner_with_fake_binary, tmp_path: Path):

--- a/python/tests/test_resfile.py
+++ b/python/tests/test_resfile.py
@@ -1,0 +1,44 @@
+"""Unit tests for the RESFILE helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from unidesign import Resfile, ResfileEntry
+
+
+def test_resfile_entry_validation() -> None:
+    with pytest.raises(ValueError):
+        ResfileEntry("", 10)
+    with pytest.raises(ValueError):
+        ResfileEntry("A", 0)
+
+
+def test_resfile_to_text_round_trip(tmp_path: Path) -> None:
+    resfile = Resfile(
+        design=(
+            ResfileEntry("A", 782, "ACDEFGHIKLMNPQRSTVWY"),
+            ResfileEntry("A", 785, ("A", "C", "F")),
+        ),
+        repack=(ResfileEntry("B", 12),),
+        catalytic=(ResfileEntry("C", 5, ["S", "T"]),),
+    )
+
+    text = resfile.to_text()
+    assert text.startswith("SITES_DESIGN_START\n")
+    assert "A  782" in text
+    assert "A  785   ACF" in text
+    assert "SITES_REPACK_START" in text
+    assert "B   12" in text
+    assert "SITES_CATALYTIC_END" in text
+
+    output_path = tmp_path / "custom.resfile"
+    written_path = resfile.write(output_path)
+    assert written_path == output_path
+    assert output_path.read_text(encoding="utf-8") == text
+
+
+def test_resfile_empty_renders_blank() -> None:
+    assert Resfile().to_text() == ""

--- a/python/unidesign/__init__.py
+++ b/python/unidesign/__init__.py
@@ -11,6 +11,7 @@ from .config import (
     ProteinDesignConfig,
 )
 from .exceptions import BinaryDiscoveryError, UniDesignError
+from .resfile import Resfile, ResfileEntry
 from .jobs import (
     BindingComputationJob,
     BindingComputationResult,
@@ -38,6 +39,8 @@ __all__ = [
     "ComputeStabilityConfig",
     "ComputeBindingConfig",
     "MakeLigParamConfig",
+    "Resfile",
+    "ResfileEntry",
     "ProteinDesignJob",
     "ProteinDesignResult",
     "StabilityComputationJob",

--- a/python/unidesign/jobs/design.py
+++ b/python/unidesign/jobs/design.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, replace
 from pathlib import Path
+from tempfile import mkstemp
 from typing import Callable, Mapping
 
 from ..artifacts import (
@@ -16,6 +18,7 @@ from ..artifacts import (
     StructureModel,
 )
 from ..config import ProteinDesignConfig
+from ..resfile import Resfile
 from ..runner import UniDesignRunner, UniDesignRunResult
 from ._shared import ArtifactSpec, relocate_artifacts
 
@@ -95,9 +98,24 @@ class ProteinDesignJob:
     ) -> ProteinDesignResult:
         """Execute the UniDesign ``ProteinDesign`` command."""
 
-        run_result = self._runner.run(
-            self._config.to_cli_args(), env=env, persist_workdir=True
-        )
+        temp_resfile_path: Path | None = None
+        config = self._config
+        try:
+            if isinstance(config.resfile_path, Resfile):
+                resfile_text = config.resfile_path.to_text()
+                fd, name = mkstemp(prefix="unidesign_resfile_", suffix=".txt")
+                os.close(fd)
+                temp_resfile_path = Path(name)
+                temp_resfile_path.write_text(resfile_text, encoding="utf-8")
+                config = replace(config, resfile_path=temp_resfile_path)
+
+            run_result = self._runner.run(
+                config.to_cli_args(), env=env, persist_workdir=True
+            )
+        finally:
+            if temp_resfile_path is not None and temp_resfile_path.exists():
+                temp_resfile_path.unlink()
+
         workspace, artifacts, cleanup = relocate_artifacts(
             run_result.workdir,
             self._candidate_files(run_result.prefix),

--- a/python/unidesign/resfile.py
+++ b/python/unidesign/resfile.py
@@ -1,0 +1,86 @@
+"""Utilities for describing and writing UniDesign RESFILE inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+@dataclass(slots=True)
+class ResfileEntry:
+    """A single residue entry within a RESFILE section."""
+
+    chain: str
+    residue: int
+    allowed: str | tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.chain:
+            raise ValueError("chain must contain at least one character")
+        if self.residue <= 0:
+            raise ValueError("residue indices must be positive")
+        allowed = self.allowed
+        if allowed is not None and not isinstance(allowed, str):
+            self.allowed = tuple(allowed)
+
+    def format_line(self) -> str:
+        """Render the entry in UniDesign RESFILE format."""
+
+        line = f"{self.chain} {self.residue:4d}"
+        allowed = self.allowed
+        if allowed:
+            allowed_str = "".join(allowed) if isinstance(allowed, tuple) else allowed
+            line = f"{line}   {allowed_str}"
+        return line
+
+
+@dataclass(slots=True)
+class Resfile:
+    """Structured representation of a UniDesign RESFILE."""
+
+    design: Sequence[ResfileEntry] | None = None
+    repack: Sequence[ResfileEntry] | None = None
+    catalytic: Sequence[ResfileEntry] | None = None
+
+    def _section_lines(
+        self, header: str, footer: str, entries: Iterable[ResfileEntry] | None
+    ) -> list[str]:
+        if not entries:
+            return []
+        lines = [header]
+        lines.extend(entry.format_line() for entry in entries)
+        lines.append(footer)
+        return lines
+
+    def to_text(self) -> str:
+        """Render the RESFILE as a string."""
+
+        lines: list[str] = []
+        lines.extend(
+            self._section_lines("SITES_DESIGN_START", "SITES_DESIGN_END", self.design)
+        )
+        lines.extend(
+            self._section_lines("SITES_REPACK_START", "SITES_REPACK_END", self.repack)
+        )
+        lines.extend(
+            self._section_lines(
+                "SITES_CATALYTIC_START", "SITES_CATALYTIC_END", self.catalytic
+            )
+        )
+        if not lines:
+            return ""
+        return "\n".join(lines) + "\n"
+
+    def write(self, path: str | Path) -> Path:
+        """Write the RESFILE to ``path`` and return the resulting :class:`Path`."""
+
+        target = Path(path)
+        if target.parent and not target.parent.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(self.to_text(), encoding="utf-8")
+        return target
+
+
+__all__ = ["Resfile", "ResfileEntry"]
+


### PR DESCRIPTION
## Summary
- add structured `Resfile` and `ResfileEntry` helpers for generating UniDesign RESFILE inputs
- update `ProteinDesignJob` to materialise in-memory RESFILE definitions for executions
- cover the new behaviour with focused unit tests and extended job smoke tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dbc9ec24248328869f1b2f9d398cd0